### PR TITLE
Add Bayesian Optimization-based PID tuning

### DIFF
--- a/nelen_control/config/ros_controllers.yaml
+++ b/nelen_control/config/ros_controllers.yaml
@@ -22,7 +22,7 @@ nelen:
   joint_state_controller:
     type: joint_state_controller/JointStateController
     publish_rate: 50
-  codo_cont:
+  codo_control:
     type: effort_controllers/JointPositionController
     joint: codo
     pid: {p: 100.0, i: 0.01, d: 10.0}

--- a/nelen_control/launch/ros_controllers.launch
+++ b/nelen_control/launch/ros_controllers.launch
@@ -6,6 +6,6 @@
 
   <!-- Load the controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" ns="/nelen" args="codo_cont hombro_control prism_control joint_state_controller"/>
+    output="screen" ns="/nelen" args="codo_control hombro_control prism_control joint_state_controller"/>
 
 </launch>

--- a/nelen_control/python/POS_sim_codo.py
+++ b/nelen_control/python/POS_sim_codo.py
@@ -140,18 +140,18 @@ def main_loop(parameter, total_time):
     rospy.init_node('nelen_step_response_example')
 
     # Create publisher for codo
-    pub_codo_cmd = rospy.Publisher('/nelen/codo_cont/command', Float64, queue_size=10)
+    pub_codo_cmd = rospy.Publisher('/nelen/codo_control/command', Float64, queue_size=10)
 
     # Create a subscriber for codo
-    sub_codo_state = rospy.Subscriber('/nelen/codo_cont/state', JointControllerState, codo_callback)
+    sub_codo_state = rospy.Subscriber('/nelen/codo_control/state', JointControllerState, codo_callback)
 
     # Set publication rate
     rate = rospy.Rate(100)  # 100hz
 
     # Set PID gains. Should fix this, seems not working.. dynamic_reconfigure?
-    rospy.set_param('/nelen/codo_cont/pid/p', parameter[0])  # set P gain
-    rospy.set_param('/nelen/codo_cont/pid/i', parameter[1])  # set I gain
-    rospy.set_param('/nelen/codo_cont/pid/d', parameter[2])  # set D gain
+    rospy.set_param('/nelen/codo_control/pid/p', parameter[0])  # set P gain
+    rospy.set_param('/nelen/codo_control/pid/i', parameter[1])  # set I gain
+    rospy.set_param('/nelen/codo_control/pid/d', parameter[2])  # set D gain
 
     # Main loop
     # We'll publish commands at the rate defined before

--- a/nelen_control/python/control_references.py
+++ b/nelen_control/python/control_references.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import math
+import numpy as np
+from scipy import signal
+
+def step_reference(t, min_angle, max_angle, period, duty=0.5):
+    # compute amplitude
+    A = max_angle - min_angle
+    # compute_vertical_offset
+    off = (max_angle + min_angle)/2
+    # compute frequency
+    f = 2*math.pi/period
+    # return step reference at time t
+    return (A*signal.square(f*t, duty) + off)

--- a/nelen_control/python/controller_sim.py
+++ b/nelen_control/python/controller_sim.py
@@ -43,10 +43,10 @@ def main_loop():
     rospy.init_node('nelen_step_response_example')
     
     # Create publisher for codo
-    pub_codo_cmd = rospy.Publisher('/nelen/codo_cont/command', Float64, queue_size=10)
+    pub_codo_cmd = rospy.Publisher('/nelen/codo_control/command', Float64, queue_size=10)
 
     # Create a subscriber for codo
-    sub_codo_state = rospy.Subscriber('/nelen/codo_cont/state', JointControllerState, codo_callback)
+    sub_codo_state = rospy.Subscriber('/nelen/codo_control/state', JointControllerState, codo_callback)
 
     # Set publication rate
     rate = rospy.Rate(100) # 100hz

--- a/nelen_control/python/nodo_bo.py
+++ b/nelen_control/python/nodo_bo.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+import time
+# Se importan paquetes importantes
+import math
+import rospy
+import numpy as np
+
+# import Float64 msg
+from std_msgs.msg import Float64
+# import control msg
+from control_msgs.msg import JointControllerState
+
+#necesario para llamar a los servicions de pausa despausa y reinicializacion
+from std_srvs.srv import Empty
+
+#paquete para cambiar los parametros del PID
+import dynamic_reconfigure.client
+
+# import bayesian optimization library
+from bayes_opt import BayesianOptimization
+
+# import control references
+import control_references as cr
+
+from functools import partial
+
+
+# This class setups all the settings to control gazebo in a structured way
+class GazeboControlExperiment:
+    def __init__(self, joint, trialTime, setpointFunction, rate=50):
+        self.joint = joint
+        self.trialTime = trialTime
+        self.setpointFunction = setpointFunction
+
+        self.rate = rospy.Rate(rate) # 50hz
+
+        # prepare structures to save data
+        self.control_error=[]
+        self.control_time=[]
+
+        # gazebo control services
+        self.reset_simulation = rospy.ServiceProxy('/gazebo/reset_simulation', Empty)
+        self.pause_simulation = rospy.ServiceProxy('/gazebo/pause_physics', Empty)
+        self.unpause_simulation = rospy.ServiceProxy('/gazebo/unpause_physics', Empty)
+
+        # prepare all the publishers
+        self.codo_client = dynamic_reconfigure.client.Client('/nelen/codo_control/pid')
+        self.codo_pub_cmd = rospy.Publisher('/nelen/codo_control/command', Float64, queue_size=10)
+        self.codo_sub_state = rospy.Subscriber('/nelen/codo_control/state', JointControllerState, self.listener_callback)
+
+        self.hombro_client = dynamic_reconfigure.client.Client('/nelen/hombro_control/pid')
+        self.hombro_pub_cmd = rospy.Publisher('/nelen/hombro_control/command', Float64, queue_size=10)
+        self.hombro_sub_state = rospy.Subscriber('/nelen/hombro_control/state', JointControllerState, self.listener_callback)
+
+        self.z_client = dynamic_reconfigure.client.Client('/nelen/prism_control/pid')
+        self.z_pub_cmd = rospy.Publisher('/nelen/prism_control/command', Float64, queue_size=10)
+        self.z_sub_state = rospy.Subscriber('/nelen/prism_control/state', JointControllerState, self.listener_callback)
+
+    def listener_callback(self, msg):
+        #se guarda el error
+        self.control_error.append(msg.error)
+        #se guarda el tiempo
+        self.control_time.append(msg.header.stamp.to_sec())
+
+    def publish_zero_command(self):
+        self.codo_pub_cmd.publish(0.0)
+        self.hombro_pub_cmd.publish(0.0)
+        self.z_pub_cmd.publish(0.0)
+
+    def publish_command(self, cmd):
+        if self.joint=='codo':
+            self.codo_pub_cmd.publish(cmd)
+            self.hombro_pub_cmd.publish(0.0)
+            self.z_pub_cmd.publish(0.0)
+
+        elif self.joint=='hombro':
+            self.codo_pub_cmd.publish(0.0)
+            self.hombro_pub_cmd.publish(cmd)
+            self.z_pub_cmd.publish(0.0)
+
+        elif self.joint=='z':
+            self.codo_pub_cmd.publish(0.0)
+            self.hombro_pub_cmd.publish(0.0)
+            self.z_pub_cmd.publish(cmd)
+        else:
+            print('not a joint')
+            exit(-1)
+
+    def update_pid_parameters(self, p, i, d):
+        params={'p': p,'i': i,'d': d}
+
+        if self.joint=='codo':
+            self.config = self.codo_client.update_configuration(params)
+        elif self.joint=='hombro':
+            self.config = self.hombro_client.update_configuration(params)
+        elif self.joint=='z':
+            self.config = self.z_client.update_configuration(params)
+        else:
+            print('not a joint')
+            exit(-1)
+        
+
+    def run_trial(self, p, i, d):
+        #rospy.loginfo("Starting trial with parameters P: %f, I: %f, D: %f" % (p,i,d))
+        # Update parameters in parameter server
+        self.update_pid_parameters(p, i, d)
+
+        # reset gazebo
+        self.reset_simulation()
+        self.unpause_simulation()
+        time.sleep(1)
+
+        # set all the joints at 0.0
+        self.publish_zero_command()
+
+        # reset the structures to save data
+        self.control_error=[]
+        self.control_time=[]
+
+        # prepare iterations
+        t_init=rospy.get_time()
+        t = rospy.get_time()
+        while True:
+            if rospy.is_shutdown():
+                rospy.logfatal("Killing the node...")
+                exit(-1)
+            
+            t = rospy.get_time() # get current time
+            #rospy.loginfo("Current time %f" % (t))
+            if (t > t_init + self.trialTime):
+                break
+            
+            # prepare command using setpoint function
+            cmd = self.setpointFunction(t-t_init)
+            # publish command
+            self.publish_command(cmd)
+            
+            # sleep to adjust to rate
+            self.rate.sleep()
+
+        # measure the finish time    
+        t_end = rospy.get_time()
+
+        # pause simulation
+        self.pause_simulation()
+        
+        # Print time
+        #print("Total time of the trial: %f s" % (t_end-t_init))
+
+        # when the trial is over, compute the error cost (SUM error^2*dt)
+        # remove first number
+        self.control_error.remove(self.control_error[0])
+        # compute the error
+        #error_cost = sum([dt*e*e for dt, e in zip(np.diff(self.control_time), self.control_error)])
+        
+        error_cost = 0
+        for dt, e in zip(np.diff(self.control_time), self.control_error):
+            if(dt < 0):
+                print("dt: %f, error: %f, term: %f" % (dt, e, dt*e*e))
+            error_cost = error_cost + dt*e*e
+
+        # return cost
+        # we put a minus sign because BO tries to maximize a function
+        # the error cost is  a sum of squares, which has a minimum at zero
+        # hence, minimizing the error is maximizing the negative cost
+        return -(error_cost) 
+
+
+# define setpoint function, must depend only on t
+# partial allows to create a new function from another one setting some of the inputs
+# in this case we set everything but t
+setpoint = partial(cr.step_reference, min_angle=np.deg2rad(45), max_angle= np.deg2rad(45), period=10, duty=0.5)
+
+# main
+if __name__ == '__main__':
+    try:
+        rospy.init_node('optimize_pid_bo')
+
+        # read parameters
+        joint = rospy.get_param('~joint', 'codo')
+        trial_time = rospy.get_param('~trial_time', 10)
+        trials = int(rospy.get_param('~trials', 20))
+
+        print("Parameters")
+        print(" Selected joint: %s" % joint)
+        print(" Time of each trial: %f s" % trial_time)
+        print(" Number of trials: %f" % trials)
+
+        # Creamos experimento
+        experiment = GazeboControlExperiment(joint, trial_time, setpoint)
+
+        # Creamos optimizador bayesiano
+        pbounds = {'p': (0.1, 10), 'i': (0.1, 10), 'd': (0.1, 10)}
+
+        optimizer = BayesianOptimization(
+            f=experiment.run_trial,
+            pbounds=pbounds,
+            random_state=1
+        )
+
+        # Optimize
+        initial_points=0
+        optimizer.maximize(init_points=initial_points, n_iter=trials)
+
+        # Show best solution
+        print("Best solution:\n cost: %f \n p: %f \n i: %f \n d: %f" % (optimizer.max["target"], optimizer.max["params"]["p"], optimizer.max["params"]["i"], optimizer.max["params"]["d"]))
+
+    except rospy.ROSInterruptException:
+        pass

--- a/nelen_control/python/nodo_pso.py
+++ b/nelen_control/python/nodo_pso.py
@@ -126,9 +126,9 @@ def run_once(p,i,d,joint):
     # suscribirse a los joints segun sea el caso
     if joint=='codo':
         #setear codo
-        client = dynamic_reconfigure.client.Client('/nelen/codo_cont/pid')
-        pub_codo_cmd = rospy.Publisher('/nelen/codo_cont/command', Float64, queue_size=10)
-        sub_codo_state = rospy.Subscriber('/nelen/codo_cont/state', JointControllerState, listener_callback)
+        client = dynamic_reconfigure.client.Client('/nelen/codo_control/pid')
+        pub_codo_cmd = rospy.Publisher('/nelen/codo_control/command', Float64, queue_size=10)
+        sub_codo_state = rospy.Subscriber('/nelen/codo_control/state', JointControllerState, listener_callback)
 
     elif joint=='hombro':
         #setear hombro

--- a/nelen_control/python/pso.py
+++ b/nelen_control/python/pso.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+from tqdm import tqdm
+import numpy as np
+import copy
+
+class Particle:
+    def __init__(self, x, c1, c2):
+        self.dim = len(x)
+        self.pos_i = x
+        self.vel_i = np.random.uniform(-1, 1, self.dim)
+        self.pos_best_i = []
+        self.err_best_i = 1
+        self.err_i = 1
+        self.c1 = c1
+        self.c2 = c2
+
+    def evaluate(self, costFunc):
+        self.err_i = costFunc(self.pos_i) # evaluate parameter's performance
+
+        # update pos_best_i and err_best_i
+        if self.err_i < self.err_best_i:
+            self.pos_best_i = self.pos_i
+            self.err_best_i = self.err_i
+
+    def update_vel(self, pos_best_g, w):
+        r1 = np.random.random(self.dim)
+        r2 = np.random.random(self.dim)
+        vel_cognitive = self.c1 * r1 * (np.array(self.pos_best_i) - np.array(self.pos_i))
+        vel_social = self.c2 * r2 * (np.array(pos_best_g) - np.array(self.pos_i))
+        self.vel_i = w * self.vel_i + vel_cognitive + vel_social
+
+    def update_pos(self, bounds):
+        self.pos_i += self.vel_i
+
+        for i in range(self.dim):
+            if self.pos_i[i] > bounds[i][1]:
+                self.pos_i[i] = bounds[i][1]
+            if self.pos_i[i] < bounds[i][0]:
+                self.pos_i[i] = bounds[i][0]
+class PSO():
+    def __init__(self, costFunc, bounds, N, iter, c1, c2, pos_best_g=[], err_best_g=1):
+        self.err_log = np.zeros((N, iter))
+        xdim = len(bounds)
+
+        self.pos_best_g = pos_best_g
+        self.err_best_g = err_best_g
+        self.bounds = bounds
+
+
+        swarm = []
+        for i in range(N):
+            xx = []
+            for d in range(xdim):
+                xx.append(np.random.uniform(bounds[d][0], bounds[d][1]))
+            swarm.append(Particle(xx, c1, c2))
+
+        print("Birds are exploring...")
+        self.i = 0
+
+    def iterate():
+        
+        while self.i < self.iterations:
+            w = np.exp(-i / iter)
+            
+            
+            for j in range(N):
+                swarm[j].evaluate(costFunc)
+                self.err_log[j, i] = swarm[j].err_i
+
+                if swarm[j].err_i < self.err_best_g:
+                    self.pos_best_g = copy.deepcopy(swarm[j].pos_i)
+                    self.err_best_g = copy.deepcopy(swarm[j].err_i)
+                pbar.update(1)
+            print("Best position so far : ", self.pos_best_g)
+            print("Best error so far : ", self.err_best_g)
+
+            for j in range(N):
+                swarm[j].update_vel(self.pos_best_g, w)
+                swarm[j].update_pos(bounds)
+
+            i += 1
+        pbar.close()
+
+        print("Iteration :", iter)
+        print("Optimized parameters :", self.pos_best_g)
+        print("Minimum error :", self.err_best_g)

--- a/nelen_utils/config/rqt_multiplot.xml
+++ b/nelen_utils/config/rqt_multiplot.xml
@@ -175,7 +175,7 @@
                                         <relative_minimum>-1000</relative_minimum>
                                         <type>0</type>
                                     </scale>
-                                    <topic>/nelen/codo_cont/command</topic>
+                                    <topic>/nelen/codo_control/command</topic>
                                     <type>std_msgs/Float64</type>
                                 </y_axis>
                             </axes>
@@ -226,7 +226,7 @@
                                         <relative_minimum>-1000</relative_minimum>
                                         <type>0</type>
                                     </scale>
-                                    <topic>/nelen/codo_cont/state</topic>
+                                    <topic>/nelen/codo_control/state</topic>
                                     <type>control_msgs/JointControllerState</type>
                                 </y_axis>
                             </axes>


### PR DESCRIPTION
@srFelipes @Wiss 

Revisé la implementación con PSO. El problema de PSO es que asume que puedes evaluar tu funcion multiples veces, para poder explorar el espacio de parámetros con cada partícula.
Sin embargo, como estan usando un simulador, requeriría evaluar 1 partícula a la vez, lo que hace que cada iteración del PSO sea super lenta, porque escala con el numero de particulas.

Agregué una implementación de calibración basada en Optimziación Bayesiana (Bayesian Optimization o BO). No se si lo cachan, pero lo investigué en su momento para mi tesis, aunque al final no lo usé. El concepto es choriflai, porque asume que la función que estás optimizando es costosa de evaluar (en este caso, un "trial" de la simulación), entonces busca el siguiente set de parámetros de manera "informada", actualizando probabilísticamente el lugar más probable donde puedes encontrar una solución mejor (usando un proceso Gaussiano).

Van a tener que instalar una libreria si:
`pip install bayesian-optimization`

Despues, tienen que lanzar el nodo que abre el simulador, y probar el nodo con
`rosrun nelen_control nodo_bo.py _joint:="codo" _trials:=20 _trial_time:=1`

Los parametros que le pueden pasar son el joint a optimizar, el numero de trials o veces que se repite el experimento, y el largo (en segundos) de cada uno. Por ahora estoy usando la misma función escalón que teniamos antes, pero pueden cambiarla, revisen la implementación. Jueguen con los parametros y las referencias para ver como hacerlo.

Además le puse que trate de mantener en 0 la referencia de los demás joints. Sin embargo, pueden cambiar la función de costo a optimizar (el error que habian puesto ustedes) para considerar todos los joints y penalizar que el resto se mueva cuando están optimizando el PID de 1 joint.

Podrían optimizar todos los joints al mismo tiempo, pero van a ser 9 parametros y BO puede explotar rápido, porque la evaluación del proceso gaussiano requiere invertir matrices y la complejidad aumenta caleta. Les recomiendo que optimicen de 1 joint a la vez, aunque pueden modificar el costo para penalizar el perturbar otros joints, como les mencioné antes.

Un problema de la implementación actual es que resetea gazebo cada vez, reiniciando el tiempo simulado, pero eso asegura la misma condición inicial para cada trial. Eso hace que el rqt_multiplot colapse y deje de funcionar despues del primer experimento. Si quieren visualizar las referencias y como se comporta con cada parametro que prueba BO, tienen que plotear los datos directamente en el nodo usando matplotlib. Lo otro sería ver como mover un objeto de gazebo artificialmente desde ROS; quizas hay un servicio para hacer eso pero no tuve tiempo de buscar mas.

Avisenme cualquier cosa.

Salu3